### PR TITLE
Update alias categories

### DIFF
--- a/Cake.ArgumentHelpers/ArgumentOrEnvironmentVariableAlias.cs
+++ b/Cake.ArgumentHelpers/ArgumentOrEnvironmentVariableAlias.cs
@@ -7,7 +7,7 @@ namespace Cake.ArgumentHelpers {
     /// <summary>
     /// Contains Aliases for helping work with combinations of Argument and Environment variables.
     /// </summary>
-	[CakeAliasCategory("Argument")]
+	[CakeAliasCategory("Arguments")]
     [CakeAliasCategory("Environment")]
     public static class ArgumentOrEnvironmentVariableAlias {
         /// <summary>
@@ -17,8 +17,7 @@ namespace Cake.ArgumentHelpers {
         /// <param name="environmentNamePrefix">An optional prefix used to qualify the same variable name when present in EnvironmentVariable form (e.g., "MySetting" command-line argument vs. "MyTool_MySetting" environment variable).</param>
         /// <returns>Value found or default, first checked in command-line argument, then environment variable.</returns>
         [CakeMethodAlias]
-        [CakeAliasCategory("Argument")]
-        [CakeAliasCategory("Environment")]
+        [CakeAliasCategory("Argument or environment variable")]
         public static bool ArgumentOrEnvironmentVariable(this ICakeContext context, string name, string environmentNamePrefix, bool defaultValue) {
             return ArgumentAliases.Argument(context, name, EnvironmentAliases.EnvironmentVariable(context, (environmentNamePrefix ?? "") + name) ?? defaultValue.ToString()).Equals("true", StringComparison.OrdinalIgnoreCase);
         }
@@ -29,8 +28,7 @@ namespace Cake.ArgumentHelpers {
         /// <param name="name">The argument name to attempt to find in either the command line parameters or environment variables.</param>
         /// <returns>Value found or default, first checked in command-line argument, then environment variable.</returns>
         [CakeMethodAlias]
-        [CakeAliasCategory("Argument")]
-        [CakeAliasCategory("Environment")]
+        [CakeAliasCategory("Argument or environment variable")]
         public static bool ArgumentOrEnvironmentVariable(this ICakeContext context, string name, bool defaultValue) {
             return context.ArgumentOrEnvironmentVariable(name, null, defaultValue);
         }
@@ -42,8 +40,7 @@ namespace Cake.ArgumentHelpers {
         /// <param name="environmentNamePrefix">An optional prefix used to qualify the same variable name when present in EnvironmentVariable form (e.g., "MySetting" command-line argument vs. "MyTool_MySetting" environment variable).</param>
         /// <returns>Value found or default, first checked in command-line argument, then environment variable.</returns>
         [CakeMethodAlias]
-        [CakeAliasCategory("Argument")]
-        [CakeAliasCategory("Environment")]
+        [CakeAliasCategory("Argument or environment variable")]
         public static string ArgumentOrEnvironmentVariable(this ICakeContext context, string name, string environmentNamePrefix, string defaultValue) {
             return ArgumentAliases.Argument<string>(context, name, EnvironmentAliases.EnvironmentVariable(context, environmentNamePrefix + name)) ?? defaultValue;
         }
@@ -55,8 +52,7 @@ namespace Cake.ArgumentHelpers {
         /// <param name="environmentNamePrefix">An optional prefix used to qualify the same variable name when present in EnvironmentVariable form (e.g., "MySetting" command-line argument vs. "MyTool_MySetting" environment variable).</param>
         /// <returns>Value found or default, first checked in command-line argument, then environment variable.</returns>
         [CakeMethodAlias]
-        [CakeAliasCategory("Argument")]
-        [CakeAliasCategory("Environment")]
+        [CakeAliasCategory("Argument or environment variable")]
         public static string ArgumentOrEnvironmentVariable(this ICakeContext context, string name, string environmentNamePrefix)
         {
             return ArgumentOrEnvironmentVariable(context, name, environmentNamePrefix, null);


### PR DESCRIPTION
Update alias categories. This will list aliases on together with out of the box argument aliases (https://cakebuild.net/dsl/arguments/). Also website doesn't support multiple categories on alias. I therefore replaced the two categories with a single one.