### PR TITLE
Update to Cake 4.0.0 and .NET 6/7/8

### DIFF
--- a/Cake.ArgumentHelpers.Tests/Cake.ArgumentHelpers.Tests.csproj
+++ b/Cake.ArgumentHelpers.Tests/Cake.ArgumentHelpers.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Cake.ArgumentHelpers.Tests</AssemblyName>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsCakeTestProject>true</IsCakeTestProject>
   </PropertyGroup>
@@ -13,8 +13,8 @@
   </ItemGroup>
   <!-- Global packages -->
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="2.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Common" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="4.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="4.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Cake.ArgumentHelpers/Cake.ArgumentHelpers.csproj
+++ b/Cake.ArgumentHelpers/Cake.ArgumentHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Cake.ArgumentHelpers</AssemblyName>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <PlatformTarget>AnyCpu</PlatformTarget>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -16,8 +16,8 @@
     <!-- Import shared functionality -->
   <Import Project="..\Shared.msbuild" />
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="2.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Common" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="4.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="4.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\asset\cake-argumenthelpers-nuget.png" Pack="true" Visible="false" PackagePath="images\icon.png" />


### PR DESCRIPTION
Fixes #15 

This pull request only contains the minimal needed changes for Cake 4.0.0 compatibility to create a intermediate release.

Updates of outdated dependencies and cleanup are performed in the pull request #17 for Cake 5.0.0